### PR TITLE
Deprecate `Used_Post_IDs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Deprecated
+
+- `Used_Post_IDs` class.
 
 ## 2.2.0
 

--- a/src/alley/wp/post-ids/class-used-post-ids.php
+++ b/src/alley/wp/post-ids/class-used-post-ids.php
@@ -11,6 +11,8 @@ use Alley\WP\Types\Post_IDs;
 
 /**
  * Track post IDs that have been used, e.g. while rendering a page.
+ *
+ * @deprecated No longer recommended.
  */
 final class Used_Post_IDs implements Post_IDs {
 	/**


### PR DESCRIPTION
## Summary

To my knowledge, one project was using this class, and its needs have evolved. See https://github.com/alleyinteractive/wp-curate/pull/193.

Since this class was already a bit naughty for including a method that wasn't part of the interface, let's put it to one side and maybe bring back an interface for recording IDs if the need comes up in a more-abstract way.

## Notes for reviewers

None.