### PR TITLE
Issue-32: Add a feature to make custom widget features registration easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor
 composer.lock
 .php_cs.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Added
+
+- `Widget_Feature` feature. #32
+- `Widget_Features` feature. #32
+- Ignore `.idea` dir from source control for PHPStorm users.
 
 ## 4.0.0
 

--- a/src/features/class-widget-feature.php
+++ b/src/features/class-widget-feature.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Widget_Feature class file
+ *
+ * Register a single widget using the feature syntax.
+ *
+ * @package wp-type-extensions
+ */
+
+declare(strict_types=1);
+
+namespace Alley\WP\Features;
+
+use Alley\WP\Types\Feature;
+use WP_Widget;
+
+/**
+ * Boot a single widget.
+ */
+final class Widget_Feature implements Feature {
+	/**
+	 * Set up.
+	 *
+	 * @param WP_Widget<array<string, mixed>>|string $widget Widget feature instance.
+	 */
+	public function __construct(
+		private readonly WP_Widget|string $widget,
+	) {}
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_action(
+			'widgets_init',
+			function (): void {
+				$widget = $this->widget;
+
+				if ( $this->widget instanceof WP_Widget ) {
+					$widget = $this->widget::class;
+				}
+
+				if ( empty( $widget ) ) {
+					return;
+				}
+
+				register_widget( $widget );
+			}
+		);
+	}
+}

--- a/src/features/class-widget-features.php
+++ b/src/features/class-widget-features.php
@@ -50,12 +50,12 @@ final class Widget_Features implements Feature {
 				foreach ( $this->widgets as $widget_class ) {
 					if ( $widget_class instanceof WP_Widget ) {
 						register_widget( $widget_class::class );
-					} elseif ( is_string( $widget_class ) ) {
+					} elseif ( is_string( $widget_class ) && ! empty( $widget_class ) ) {
 						register_widget( $widget_class );
 					} else {
 						_doing_it_wrong(
 							__METHOD__,
-							esc_html__( 'To register a Widget Feature, you need to pass a WP_Widget or string.', 'wp-type-extensions' ),
+							esc_html__( 'To register widget features, you need to pass a WP_Widget or string.', 'wp-type-extensions' ),
 							'1.0.0'
 						);
 					}

--- a/src/features/class-widget-features.php
+++ b/src/features/class-widget-features.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Widget_Feature class file
+ *
+ * Register several widgets using the feature syntax.
+ *
+ * @package wp-type-extensions
+ */
+
+declare(strict_types=1);
+
+namespace Alley\WP\Features;
+
+use Alley\WP\Types\Feature;
+use WP_Widget;
+
+/**
+ * Boot several widgets.
+ */
+final class Widget_Features implements Feature {
+	/**
+	 * Widgets to include.
+	 *
+	 * @var WP_Widget<array<string, mixed>>[]|string[]
+	 */
+	private array $widgets = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_Widget<array<string, mixed>>[]|WP_Widget<array<string, mixed>>|string|string[] ...$widgets Widgets.
+	 */
+	public function __construct( ...$widgets ) {
+		foreach ( $widgets as $widget ) {
+			if ( is_array( $widget ) ) {
+				array_push( $this->widgets, ...$widget );
+			} else {
+				$this->widgets[] = $widget;
+			}
+		}
+	}
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_action(
+			'widgets_init',
+			function (): void {
+				foreach ( $this->widgets as $widget_class ) {
+					if ( $widget_class instanceof WP_Widget ) {
+						register_widget( $widget_class::class );
+					} elseif ( is_string( $widget_class ) ) {
+						register_widget( $widget_class );
+					} else {
+						_doing_it_wrong(
+							__METHOD__,
+							esc_html__( 'To register a Widget Feature, you need to pass a WP_Widget or string.', 'wp-type-extensions' ),
+							'1.0.0'
+						);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Include widgets.
+	 *
+	 * @param WP_Widget<array<string, mixed>>[]|WP_Widget<array<string, mixed>>|string|string[] ...$widgets Widgets to include.
+	 */
+	public function include( ...$widgets ): void {
+		array_push( $this->widgets, ...$widgets );
+	}
+}

--- a/tests/Feature/WidgetFeatureTest.php
+++ b/tests/Feature/WidgetFeatureTest.php
@@ -5,6 +5,8 @@
  * @package wp-type-extensions
  */
 
+declare(strict_types=1);
+
 namespace Alley\WP\Tests\Feature;
 
 use Alley\WP\Features\Widget_Feature;
@@ -98,5 +100,15 @@ class WidgetFeatureTest extends Test_Case {
 		unregister_widget( $widget_class_2::class );
 
 		$this->assertArrayNotHasKey( $widget_class_2::class, $wp_widget_factory->widgets );
+	}
+
+	public function test_register_a_widget_with_invalid(): void {
+		$widget_feature = new Widget_Features( '' );
+		$widget_feature->boot();
+
+		// Register widgets.
+		do_action( 'widgets_init' );
+
+		$this->setExpectedIncorrectUsage( '{closure:Alley\WP\Features\Widget_Features::boot():49}' );
 	}
 }

--- a/tests/Feature/WidgetFeatureTest.php
+++ b/tests/Feature/WidgetFeatureTest.php
@@ -153,6 +153,6 @@ class WidgetFeatureTest extends Test_Case {
 		// Register widgets.
 		do_action( 'widgets_init' );
 
-		$this->setExpectedIncorrectUsage( '{closure:Alley\WP\Features\Widget_Features::boot():49}' );
+		$this->setExpectedIncorrectUsage( 'Alley\WP\Features\{closure}' );
 	}
 }

--- a/tests/Feature/WidgetFeatureTest.php
+++ b/tests/Feature/WidgetFeatureTest.php
@@ -2,6 +2,8 @@
 /**
  * WidgetFeatureTest class file
  *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+ *
  * @package wp-type-extensions
  */
 
@@ -19,14 +21,29 @@ use WP_Widget;
  */
 class WidgetFeatureTest extends Test_Case {
 
+	/**
+	 * Test that a single widget feature is registered correctly.
+	 */
 	public function test_register_a_single_widget_feature(): void {
 		global $wp_widget_factory;
 
-		$widget_class = new class extends WP_Widget {
+		$widget_class = new class() extends WP_Widget {
+
+			/**
+			 * Constructor.
+			 */
 			public function __construct() {
 				parent::__construct( 'test_widget', 'Test Widget' );
 			}
 
+			/**
+			 * Widget output.
+			 *
+			 * @param array  $args Args.
+			 * @param object $instance Widget instance.
+			 *
+			 * @return string
+			 */
 			public function widget( $args, $instance ): string {
 				echo '<div>Test Widget</div>';
 				return '';
@@ -55,22 +72,46 @@ class WidgetFeatureTest extends Test_Case {
 	public function test_register_several_widget_features(): void {
 		global $wp_widget_factory;
 
-		$widget_class_1 = new class extends WP_Widget {
+		$widget_class_1 = new class() extends WP_Widget {
+
+			/**
+			 * Constructor.
+			 */
 			public function __construct() {
 				parent::__construct( 'test_widget_1', 'Test Widget 1' );
 			}
 
+			/**
+			 * Widget output.
+			 *
+			 * @param array  $args Args.
+			 * @param object $instance Widget instance.
+			 *
+			 * @return string
+			 */
 			public function widget( $args, $instance ): string {
 				echo '<div>Test Widget 1</div>';
 				return '';
 			}
 		};
 
-		$widget_class_2 = new class extends WP_Widget {
+		$widget_class_2 = new class() extends WP_Widget {
+
+			/**
+			 * Constructor.
+			 */
 			public function __construct() {
 				parent::__construct( 'test_widget_2', 'Test Widget 2' );
 			}
 
+			/**
+			 * Widget output.
+			 *
+			 * @param array  $args Args.
+			 * @param object $instance Widget instance.
+			 *
+			 * @return string
+			 */
 			public function widget( $args, $instance ): string {
 				echo '<div>Test Widget 2</div>';
 				return '';
@@ -102,6 +143,9 @@ class WidgetFeatureTest extends Test_Case {
 		$this->assertArrayNotHasKey( $widget_class_2::class, $wp_widget_factory->widgets );
 	}
 
+	/**
+	 * Test that an exception is thrown when a widget class is not valid.
+	 */
 	public function test_register_a_widget_with_invalid(): void {
 		$widget_feature = new Widget_Features( '' );
 		$widget_feature->boot();

--- a/tests/Feature/WidgetFeatureTest.php
+++ b/tests/Feature/WidgetFeatureTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * WidgetFeatureTest class file
+ *
+ * @package wp-type-extensions
+ */
+
+namespace Alley\WP\Tests\Feature;
+
+use Alley\WP\Features\Widget_Feature;
+use Alley\WP\Features\Widget_Features;
+use Mantle\Testkit\Test_Case;
+use WP_Widget;
+
+/**
+ * WidgetFeatureTest test case.
+ */
+class WidgetFeatureTest extends Test_Case {
+
+	public function test_register_a_single_widget_feature(): void {
+		global $wp_widget_factory;
+
+		$widget_class = new class extends WP_Widget {
+			public function __construct() {
+				parent::__construct( 'test_widget', 'Test Widget' );
+			}
+
+			public function widget( $args, $instance ): string {
+				echo '<div>Test Widget</div>';
+				return '';
+			}
+		};
+
+		$this->assertTrue( class_exists( $widget_class::class ) );
+		$this->assertInstanceOf( WP_Widget::class, $widget_class );
+
+		$widget_feature = new Widget_Feature( $widget_class::class );
+		$widget_feature->boot();
+
+		// Register widgets.
+		do_action( 'widgets_init' );
+
+		$this->assertArrayHasKey( $widget_class::class, $wp_widget_factory->widgets );
+
+		unregister_widget( $widget_class::class );
+
+		$this->assertArrayNotHasKey( $widget_class::class, $wp_widget_factory->widgets );
+	}
+
+	/**
+	 * This test is similar to the previous one, but it registers multiple widgets.
+	 */
+	public function test_register_several_widget_features(): void {
+		global $wp_widget_factory;
+
+		$widget_class_1 = new class extends WP_Widget {
+			public function __construct() {
+				parent::__construct( 'test_widget_1', 'Test Widget 1' );
+			}
+
+			public function widget( $args, $instance ): string {
+				echo '<div>Test Widget 1</div>';
+				return '';
+			}
+		};
+
+		$widget_class_2 = new class extends WP_Widget {
+			public function __construct() {
+				parent::__construct( 'test_widget_2', 'Test Widget 2' );
+			}
+
+			public function widget( $args, $instance ): string {
+				echo '<div>Test Widget 2</div>';
+				return '';
+			}
+		};
+
+		$this->assertTrue( class_exists( $widget_class_1::class ) );
+		$this->assertTrue( class_exists( $widget_class_2::class ) );
+		$this->assertInstanceOf( WP_Widget::class, $widget_class_1 );
+		$this->assertInstanceOf( WP_Widget::class, $widget_class_2 );
+
+		$widget_feature = new Widget_Features( $widget_class_1::class );
+		$widget_feature->include( $widget_class_2::class );
+		$widget_feature->boot();
+
+		// Register widgets.
+		do_action( 'widgets_init' );
+
+		$this->assertArrayHasKey( $widget_class_1::class, $wp_widget_factory->widgets );
+		$this->assertArrayHasKey( $widget_class_2::class, $wp_widget_factory->widgets );
+
+		unregister_widget( $widget_class_1::class );
+
+		$this->assertArrayNotHasKey( $widget_class_1::class, $wp_widget_factory->widgets );
+		$this->assertArrayHasKey( $widget_class_2::class, $wp_widget_factory->widgets );
+
+		unregister_widget( $widget_class_2::class );
+
+		$this->assertArrayNotHasKey( $widget_class_2::class, $wp_widget_factory->widgets );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #32. Adds a feature to simplify custom widget registration by introducing new classes and functionality for feature-based widget management.

## Notes for reviewers

- The `.idea` directory has been added to the `.gitignore` file to avoid tracking IDE-specific files.
- Unit tests have been added for the new widget-related functionality.

## Changelog entries

### Added
- A new feature for easier custom widget registration:
  - Introduced the `Widget_Feature` class to register single WordPress widgets using a feature-based syntax.
  - Introduced the `Widget_Features` class to register multiple WordPress widgets via the `widgets_init` action hook.
  - Added unit tests for the widget-related functionality in `tests/Feature/WidgetFeatureTest.php`.
- Updated `.gitignore` to exclude `.idea` directories for JetBrains IDE users.

### Changed
- Updated the `CHANGELOG.md` file with details of the new features under the "Unreleased" section.

### Deprecated

### Removed

### Fixed

### Security