### PR TITLE
Issue-35: Support PHP 8.4

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -17,7 +17,7 @@ jobs:
     # Define a matrix of PHP/WordPress versions to test against
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         wordpress: ["latest"]
         multisite: [false, true]
     runs-on: ubuntu-latest

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -28,6 +28,9 @@
   <!-- In effect, set the minimum supported version of WordPress to the latest version. -->
   <config name="minimum_supported_wp_version" value="99.0"/>
 
+  <!-- Configure the PHP version -->
+  <config name="testVersion" value="8.2-" />
+
   <!-- Define the prefixes that can be used by the plugin -->
   <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
     <properties>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 - `Widget_Feature` feature. #32
 - `Widget_Features` feature. #32
 - Ignore `.idea` dir from source control for PHPStorm users.
+- CI: support PHP 8.4. #35
+
+### Changed
+
+- PHPCS: The minimum PHP version is now 8.2.
+- Unit test: `WidgetFeatureTest` test works por PHP 8.3 and 8.4.
 
 ## 4.0.0
 

--- a/tests/Feature/WidgetFeatureTest.php
+++ b/tests/Feature/WidgetFeatureTest.php
@@ -153,6 +153,7 @@ class WidgetFeatureTest extends Test_Case {
 		// Register widgets.
 		do_action( 'widgets_init' );
 
-		$this->setExpectedIncorrectUsage( 'Alley\WP\Features\{closure}' );
+		// Until Mantle supports it.
+		$this->ignoreIncorrectUsage( '*Alley\WP\Features*' );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #35. Support PHP 8.4. Update CI and improve compatibility configurations.

## Notes for reviewers

- CI now includes PHP 8.4 in the testing matrix.  
- Adjustments have been made to PHPCS configurations to ensure compatibility with PHP 8.2 and above.  
- Minor updates to test methods were introduced for compatibility, with a note indicating temporary adjustments until Mantle support is added.

## Changelog entries

### Added

- Support for PHP 8.4.
- CI: Testing matrix updated to include PHP 8.4.

### Changed

- Updated CI configurations to support PHP 8.4.
- PHPCS: Adjusted configuration to set the minimum compatible PHP version to 8.2.
- Modified test methods for compatibility with PHP 8.4, including temporary changes related to Mantle support.

### Deprecated

### Removed

### Fixed

### Security