### PR TITLE
Issue-37: Support PHPStan 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Changed
 
-- PHPStan: upgraded to 2.0. [#37](https://github.com/alleyinteractive/wp-type-extensions/issues/37)
+- PHPStan: upgraded to 2.0.
 - PHPCS: The minimum PHP version is now 8.2.
 - Unit test: `WidgetFeatureTest` test works por PHP 8.3 and 8.4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Changed
 
+- PHPStan: upgraded to 2.0. [#37](https://github.com/alleyinteractive/wp-type-extensions/issues/37)
 - PHPCS: The minimum PHP version is now 8.2.
 - Unit test: `WidgetFeatureTest` test works por PHP 8.3 and 8.4.
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "alleyinteractive/alley-coding-standards": "^2.0",
     "ergebnis/composer-normalize": "^2.44",
     "mantle-framework/testkit": "^1.2",
-    "szepeviktor/phpstan-wordpress": "^1.3"
+    "szepeviktor/phpstan-wordpress": "^2.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,12 @@ includes:
 parameters:
 	# Level 9 is the highest level
 	level: max
+	tips:
+	  treatPhpDocTypesAsCertain: false
 
 	paths:
 		- src/
+
+	ignoreErrors:
+	  -
+	      identifier: function.alreadyNarrowedType

--- a/src/blocks/class-parsed-block.php
+++ b/src/blocks/class-parsed-block.php
@@ -8,7 +8,6 @@
 namespace Alley\WP\Blocks;
 
 use Alley\WP\Types\Single_Block;
-use WP_Block_Parser_Block;
 
 /**
  * A single parsed block.
@@ -17,9 +16,7 @@ final class Parsed_Block implements Single_Block {
 	/**
 	 * Set up.
 	 *
-	 * @phpstan-param array<mixed> $origin
-	 *
-	 * @param array $origin Parsed block.
+	 * @param array<mixed> $origin Parsed block.
 	 */
 	public function __construct(
 		private readonly array $origin,
@@ -37,7 +34,13 @@ final class Parsed_Block implements Single_Block {
 	/**
 	 * Parsed block.
 	 *
-	 * @phpstan-return array{blockName: ?string, attrs: array<string, mixed>, innerBlocks: array<mixed[]>, innerHTML: string, innerContent: string[]}
+	 * @phpstan-return array{
+	 *     blockName: ?string,
+	 *     attrs: array<string|int, mixed>,
+	 *     innerBlocks: array<int|string, mixed>,
+	 *     innerHTML: string,
+	 *     innerContent: array<int|string, mixed>
+	 * }
 	 *
 	 * @return array
 	 */

--- a/src/features/library/class-allowed-blocks.php
+++ b/src/features/library/class-allowed-blocks.php
@@ -44,12 +44,17 @@ final class Allowed_Blocks implements Feature {
 	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 * @return bool|string[] Updated block type slugs.
 	 */
-	public function filter_allowed_block_types( $allowed_block_types, $block_editor_context ) {
+	public function filter_allowed_block_types( $allowed_block_types, $block_editor_context ): array|bool {
 		if ( in_array( $block_editor_context->name, (array) $this->context, true ) ) {
+			/**
+			 * Tell PHPStan the returned value is an array.
+			 *
+			 * @var string[] $updated
+			 */
 			$updated = array_reduce(
 				$this->registry->get_all_registered(),
 				function ( array $carry, WP_Block_Type $type ) {
-					if ( $this->allowed->isValid( $type->name ) ) {
+					if ( $this->allowed->isValid( $type->name ) && is_string( $type->name ) ) {
 						$carry[] = $type->name;
 					}
 
@@ -63,7 +68,9 @@ final class Allowed_Blocks implements Feature {
 				array_push( $updated, ...array_filter( $allowed_block_types, [ $this->allowed, 'isValid' ] ) );
 			}
 
-			$allowed_block_types = $updated;
+			if ( is_array( $updated ) ) {
+				$allowed_block_types = $updated;
+			}
 		}
 
 		return $allowed_block_types;

--- a/src/features/library/class-block-content-filter.php
+++ b/src/features/library/class-block-content-filter.php
@@ -18,6 +18,8 @@ final class Block_Content_Filter implements Feature {
 	/**
 	 * Callback to merge blocks.
 	 *
+	 * @phpstan-var callable(Serialized_Blocks $post_content): Serialized_Blocks
+	 *
 	 * @var callable
 	 */
 	private $block_merge;
@@ -48,12 +50,21 @@ final class Block_Content_Filter implements Feature {
 	 * @param string $content Content of the current post.
 	 * @return string Updated content.
 	 */
-	public function filter_the_content( $content ) {
+	public function filter_the_content( string $content ): string {
 		$post = get_post();
 
 		// Skip if 'the_content' is running on non-block content or on content other than the post being viewed.
-		if ( $post && is_single( $post->ID ) && has_blocks( $content ) ) {
+		if (
+			$post
+			&& is_callable( $this->block_merge )
+			&& is_single( $post->ID )
+			&& has_blocks( $content )
+		) {
 			$content = ( $this->block_merge )( new Block_Content( $content ) )->serialized_blocks();
+		}
+
+		if ( ! is_string( $content ) ) {
+			$content = '';
 		}
 
 		return $content;

--- a/src/features/library/class-block-content-filter.php
+++ b/src/features/library/class-block-content-filter.php
@@ -56,7 +56,6 @@ final class Block_Content_Filter implements Feature {
 		// Skip if 'the_content' is running on non-block content or on content other than the post being viewed.
 		if (
 			$post
-			&& is_callable( $this->block_merge )
 			&& is_single( $post->ID )
 			&& has_blocks( $content )
 		) {

--- a/src/features/library/class-plugin-loader.php
+++ b/src/features/library/class-plugin-loader.php
@@ -17,7 +17,7 @@ final class Plugin_Loader implements Feature {
 	/**
 	 * Constructor.
 	 *
-	 * @param string[] $plugins List of plugins to load.
+	 * @param array<int, string> $plugins List of plugins to load.
 	 */
 	public function __construct(
 		private readonly array $plugins,

--- a/src/post-ids/class-wp-query-post-ids.php
+++ b/src/post-ids/class-wp-query-post-ids.php
@@ -58,7 +58,7 @@ final class WP_Query_Post_IDs implements Post_IDs {
 		}
 
 		// fields => 'id=>parent'.
-		if ( ( $value instanceof \stdClass ) && isset( $value->ID ) ) {
+		if ( ( $value instanceof \stdClass ) && isset( $value->ID ) && is_numeric( $value->ID ) ) {
 			$id = $value->ID;
 		}
 


### PR DESCRIPTION
## Summary

Fixes #37. Support PHPStan 2.0.

## Notes for reviewers

- The `composer.json` file has been updated to require `szepeviktor/phpstan-wordpress` version `^2.0`.
- Several changes were made to improve type safety, enhance documentation, and update PHPStan configurations to align with version 2.0.
- The `ignoreErrors` section and additional configuration options have been introduced to accommodate stricter type checks while maintaining flexibility where necessary.

## Changelog entries

### Added

- New PHPStan configuration options, including `treatPhpDocTypesAsCertain: false` and an `ignoreErrors` section to handle specific rules.
- Type annotations for methods and properties, improving type safety and code clarity.

### Changed

- Support PHPStan 2.0.
- Updated `composer.json` to require `szepeviktor/phpstan-wordpress` version `^2.0`.
- Enhanced type safety in various methods by adding explicit type checks and return type declarations.
- Improved PHPDoc comments for better precision and clarity, including updated annotations for parameters and properties.

### Deprecated

### Removed

- Removed the unused `use WP_Block_Parser_Block` statement from the `Parsed_Block` class.

### Fixed

- Ensured numeric validation for the `ID` property in `stdClass` objects before processing, preventing potential errors.

### Security

- Improved handling of data integrity by validating types more strictly where necessary.