### PR TITLE
Remove spread support from `Features::include()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Added
 
-- `Widget_Feature` feature. #32
-- `Widget_Features` feature. #32
-- Ignore `.idea` dir from source control for PHPStorm users.
-- CI: support PHP 8.4. #35
+- `Widget_Feature` feature.
+- `Widget_Features` feature.
+- PHP 8.4 support.
 
 ### Changed
 
-- PHPCS: The minimum PHP version is now 8.2.
-- Unit test: `WidgetFeatureTest` test works por PHP 8.3 and 8.4.
+- `Features::include()` no longer accepts a spread of individual `Feature` instances. Use something more specific like `Group` or `Ordered` to include multiple features at once.
 
 ## 4.0.0
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ The `Features` interface describes multiple project features. This interface ext
 
 ```php
 interface Features extends Feature{
-	public function include( Feature ...$features ): void;
+	public function include( Feature $feature ): void;
 }
 ```
 

--- a/src/features/class-group.php
+++ b/src/features/class-group.php
@@ -40,11 +40,11 @@ final class Group implements Features {
 	}
 
 	/**
-	 * Include features.
+	 * Include a feature.
 	 *
-	 * @param Feature ...$features Features to include.
+	 * @param Feature $feature Feature to include.
 	 */
-	public function include( Feature ...$features ): void {
-		array_push( $this->features, ...$features );
+	public function include( Feature $feature ): void {
+		$this->features[] = $feature;
 	}
 }

--- a/src/types/interface-features.php
+++ b/src/types/interface-features.php
@@ -12,9 +12,9 @@ namespace Alley\WP\Types;
  */
 interface Features extends Feature {
 	/**
-	 * Include features.
+	 * Include a feature.
 	 *
-	 * @param Feature ...$features Features to include.
+	 * @param Feature $feature Feature to include.
 	 */
-	public function include( Feature ...$features ): void;
+	public function include( Feature $feature ): void;
 }


### PR DESCRIPTION
## Summary

Inspired by the comment from @renatonascalves here: https://github.com/alleyinteractive/wp-type-extensions/pull/34#issuecomment-2831331278

Also, by an internal discussion about how to break large features into smaller feature classes while still communicating their relationship to one another.

The `Features` and `Group` vocabulary already exists to describe multiple features. Allowing an arbitrary number of individual feature classes to be passed seems to me to discourage using that vocabulary.

I also updated a couple lines in the CHANGELOG to be more consistent with previous entries and removed a couple that didn't seem relevant for package users.

## Notes for reviewers

None.