### PR TITLE
[3.x] Adding alleyinteractive/wp-plugin-loader 1.0 support

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - *.x
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -39,8 +39,9 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '${{ matrix.php }}'
-          wordpress-version: '${{ matrix.wordpress }}'
+          skip-audit: 'true'
           skip-wordpress-install: 'true'
+          wordpress-version: '${{ matrix.wordpress }}'
   # This required job ensures that all PR checks have passed before merging.
   all-pr-checks-passed:
     name: All PR checks passed

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -18,16 +18,15 @@ jobs:
     # Define a matrix of PHP/WordPress versions to test against
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         wordpress: ["latest"]
-        multisite: [false, true]
     runs-on: ubuntu-latest
     # Cancel any existing runs of this workflow
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite }}
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
       cancel-in-progress: true
     # Name the job in the matrix
-    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} multisite ${{ matrix.multisite }}"
+    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +39,25 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '${{ matrix.php }}'
-          audit-command: 'composer audit --no-dev --ansi --no-interaction'
           wordpress-version: '${{ matrix.wordpress }}'
-          wordpress-multisite: '${{ matrix.multisite }}'
           skip-wordpress-install: 'true'
+  # This required job ensures that all PR checks have passed before merging.
+  all-pr-checks-passed:
+    name: All PR checks passed
+    needs:
+      - pr-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check job statuses
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs were cancelled"
+            exit 1
+          else
+            echo "All jobs passed or were skipped"
+            exit 0
+          fi

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - *.x
+      - '*.x'
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 3.1.0
+
+- Adjusted `alleyinteractive/wp-plugin-loader` to support version 1.0.
+
 ## 3.0.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": "^8.2",
     "alleyinteractive/laminas-validator-extensions": "^2.0",
     "alleyinteractive/wp-match-blocks": "^3.0",
-    "alleyinteractive/wp-plugin-loader": "^0.1.5",
+    "alleyinteractive/wp-plugin-loader": "^0.1.5 || ^1.0",
     "spatie/once": "^3.1"
   },
   "require-dev": {


### PR DESCRIPTION
Backporting https://github.com/alleyinteractive/wp-type-extensions/pull/41 to 3.x.