### PR TITLE
Updating the CI workflow

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - '*.x'
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
@@ -19,14 +20,13 @@ jobs:
       matrix:
         php: [8.2, 8.3, 8.4]
         wordpress: ["latest"]
-        multisite: [false, true]
     runs-on: ubuntu-latest
     # Cancel any existing runs of this workflow
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite }}
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
       cancel-in-progress: true
     # Name the job in the matrix
-    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} multisite ${{ matrix.multisite }}"
+    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,25 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '${{ matrix.php }}'
-          audit-command: 'composer audit --no-dev --ansi --no-interaction'
           wordpress-version: '${{ matrix.wordpress }}'
-          wordpress-multisite: '${{ matrix.multisite }}'
           skip-wordpress-install: 'true'
+  # This required job ensures that all PR checks have passed before merging.
+  all-pr-checks-passed:
+    name: All PR checks passed
+    needs:
+      - pr-tests
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check job statuses
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs were cancelled"
+            exit 1
+          else
+            echo "All jobs passed or were skipped"
+            exit 0
+          fi

--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -39,8 +39,9 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '${{ matrix.php }}'
-          wordpress-version: '${{ matrix.wordpress }}'
+          skip-audit: 'true'
           skip-wordpress-install: 'true'
+          wordpress-version: '${{ matrix.wordpress }}'
   # This required job ensures that all PR checks have passed before merging.
   all-pr-checks-passed:
     name: All PR checks passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ### Changed
 
-- Adjusted `alleyinteractive/wp-plugin-loader` to support version 1.0.
 - `Features::include()` no longer accepts a spread of individual `Feature` instances. Use something more specific like `Group` or `Ordered` to include multiple features at once.
 
 ## 4.0.0
@@ -28,6 +27,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 ### Removed
 
 - `Matched_Blocks` class, now part of the [Match Blocks](https://packagist.org/packages/alleyinteractive/wp-match-blocks) library.
+
+## 3.1.0
+
+- Adjusted `alleyinteractive/wp-plugin-loader` to support version 1.0.
 
 ## 3.0.0
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,4 +10,6 @@
  * @package wp-type-extensions
  */
 
-\Mantle\Testing\install();
+\Mantle\Testing\manager()
+	->with_sqlite()
+	->install();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,4 @@
  * @package wp-type-extensions
  */
 
-\Mantle\Testing\manager()
-	->with_sqlite()
-	->install();
+\Mantle\Testing\install();


### PR DESCRIPTION
- Updating CI to match https://github.com/alleyinteractive/create-wordpress-plugin
- Updating changelog to reflect https://github.com/alleyinteractive/wp-type-extensions/pull/42 backporting the change to 3.x (3.1.0)
