### PR TITLE
Issue-49: PHPStan: Flatten array for the `Widget_Features::includes` method

### DIFF
--- a/src/features/class-widget-features.php
+++ b/src/features/class-widget-features.php
@@ -70,6 +70,12 @@ final class Widget_Features implements Feature {
 	 * @param WP_Widget<array<string, mixed>>[]|WP_Widget<array<string, mixed>>|string|string[] ...$widgets Widgets to include.
 	 */
 	public function include( ...$widgets ): void {
-		array_push( $this->widgets, ...$widgets );
+		foreach ( $widgets as $widget ) {
+			if ( is_array( $widget ) ) {
+				array_push( $this->widgets, ...$widget );
+			} else {
+				$this->widgets[] = $widget;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #49. This PR addresses a PHPStan type issue by flattening the array for the `Widget_Features::includes` method.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

- Updated the `Widget_Features::includes` method to flatten the input array, ensuring all widgets are properly appended and resolving type inconsistencies.

### Deprecated

### Removed

### Fixed

- Resolved PHPStan type issue by modifying the behavior of the `Widget_Features::includes` method to correctly flatten and append widget arguments.

### Security